### PR TITLE
Use language autonyms and localize Japanese nav labels

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,6 +7,11 @@ import { ColorModeButton } from "./ui/color-mode";
 import { useTranslation } from "react-i18next";
 import { supportedLanguages, type SupportedLanguage } from "@/lib/i18n";
 
+const LANGUAGE_LABELS: Record<SupportedLanguage, string> = {
+  ja: "日本語",
+  en: "English",
+};
+
 const Header: React.FC = () => {
   const { t, i18n } = useTranslation();
   const { lang } = useParams();
@@ -93,7 +98,7 @@ const Header: React.FC = () => {
               px="2"
             >
               <TbLanguage />
-              {t(`language.${currentLanguage}`)}
+              {LANGUAGE_LABELS[currentLanguage]}
               <TbChevronDown />
             </Button>
           </Menu.Trigger>
@@ -114,7 +119,7 @@ const Header: React.FC = () => {
                         }
                         aria-hidden
                       />
-                      {t(`language.${language}`)}
+                      {LANGUAGE_LABELS[language]}
                     </Flex>
                   </Menu.Item>
                 ))}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -42,9 +42,9 @@ const resources = {
       },
       header: {
         nav: {
-          home: "Home",
-          help: "Help",
-          theory: "Theory",
+          home: "ホーム",
+          help: "ヘルプ",
+          theory: "理論",
         },
         languageLabel: "表示言語",
       },

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -30,10 +30,6 @@ const getLanguageFromPathname = (): SupportedLanguage | null => {
 const resources = {
   ja: {
     translation: {
-      language: {
-        ja: "日本語",
-        en: "英語",
-      },
       common: {
         appName: "読み合いナッシュ",
         appDescription:
@@ -168,10 +164,6 @@ const resources = {
   },
   en: {
     translation: {
-      language: {
-        ja: "Japanese",
-        en: "English",
-      },
       common: {
         appName: "Yomi Nash",
         appDescription:


### PR DESCRIPTION
## 概要

  - ヘッダーメニューの言語選択表示を自己表記（日本語／English）で統一し、未使用となった i18n キーを整理しました。
  - 日本語ロケールで Home/Help/Theory をそれぞれ「ホーム」「ヘルプ」「理論」にローカライズしました。
