### PR TITLE
Use X share intent URL

### DIFF
--- a/src/pages/Home/TableControls/useTableControls.ts
+++ b/src/pages/Home/TableControls/useTableControls.ts
@@ -15,6 +15,7 @@ import {
   generateCsvFromGameInputUI,
   parseCsvInputFromBinary,
 } from "@/utils/parseCsvInput";
+import { createXShareIntent } from "@/utils/createXShareIntent";
 import { useTranslation } from "react-i18next";
 
 interface UseTableControlsParams {
@@ -143,10 +144,10 @@ export const useTableControls = ({
   const handleShare = useCallback(() => {
     try {
       const shareUrl = createShareUrl(inputUI, { result });
-      const text = encodeURIComponent(t("home.tableControls.shareTweet"));
-      const intent = `https://twitter.com/intent/tweet?text=${text}&url=${encodeURIComponent(
-        shareUrl
-      )}`;
+      const intent = createXShareIntent({
+        text: t("home.tableControls.shareTweet"),
+        url: shareUrl,
+      });
       window.open(intent, "_blank", "noopener,noreferrer");
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);

--- a/src/utils/__tests__/createXShareIntent.test.ts
+++ b/src/utils/__tests__/createXShareIntent.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { createXShareIntent } from "@/utils/createXShareIntent";
+
+describe("createXShareIntent", () => {
+  it("builds an X share intent URL with encoded text and URL", () => {
+    const intent = createXShareIntent({
+      text: "Yomi Nash | 格闘ゲームの読み合い分析アプリ #yominash",
+      url: "https://example.com/ja?schemaVersion=1&gameInput=shared",
+    });
+
+    expect(intent).toBe(
+      "https://x.com/intent/tweet?text=Yomi+Nash+%7C+%E6%A0%BC%E9%97%98%E3%82%B2%E3%83%BC%E3%83%A0%E3%81%AE%E8%AA%AD%E3%81%BF%E5%90%88%E3%81%84%E5%88%86%E6%9E%90%E3%82%A2%E3%83%97%E3%83%AA+%23yominash&url=https%3A%2F%2Fexample.com%2Fja%3FschemaVersion%3D1%26gameInput%3Dshared"
+    );
+  });
+});

--- a/src/utils/__tests__/createXShareIntent.test.ts
+++ b/src/utils/__tests__/createXShareIntent.test.ts
@@ -4,13 +4,17 @@ import { createXShareIntent } from "@/utils/createXShareIntent";
 
 describe("createXShareIntent", () => {
   it("builds an X share intent URL with encoded text and URL", () => {
+    const text = "Yomi Nash | 格闘ゲームの読み合い分析アプリ #yominash";
+    const url = "https://example.com/ja?schemaVersion=1&gameInput=shared";
     const intent = createXShareIntent({
-      text: "Yomi Nash | 格闘ゲームの読み合い分析アプリ #yominash",
-      url: "https://example.com/ja?schemaVersion=1&gameInput=shared",
+      text,
+      url,
     });
+    const parsedIntent = new URL(intent);
 
-    expect(intent).toBe(
-      "https://x.com/intent/tweet?text=Yomi+Nash+%7C+%E6%A0%BC%E9%97%98%E3%82%B2%E3%83%BC%E3%83%A0%E3%81%AE%E8%AA%AD%E3%81%BF%E5%90%88%E3%81%84%E5%88%86%E6%9E%90%E3%82%A2%E3%83%97%E3%83%AA+%23yominash&url=https%3A%2F%2Fexample.com%2Fja%3FschemaVersion%3D1%26gameInput%3Dshared"
-    );
+    expect(parsedIntent.origin).toBe("https://x.com");
+    expect(parsedIntent.pathname).toBe("/intent/tweet");
+    expect(parsedIntent.searchParams.get("text")).toBe(text);
+    expect(parsedIntent.searchParams.get("url")).toBe(url);
   });
 });

--- a/src/utils/createXShareIntent.ts
+++ b/src/utils/createXShareIntent.ts
@@ -1,0 +1,15 @@
+export interface CreateXShareIntentOptions {
+  text: string;
+  url: string;
+}
+
+export function createXShareIntent({
+  text,
+  url,
+}: CreateXShareIntentOptions): string {
+  const params = new URLSearchParams();
+  params.set("text", text);
+  params.set("url", url);
+
+  return `https://x.com/intent/tweet?${params.toString()}`;
+}


### PR DESCRIPTION
## Summary
- Replace the share button's Web Intent endpoint from `twitter.com` to `x.com`.
- Add a small utility for building X share intent URLs.
- Cover the intent URL generation with a unit test.

## Why
Issue #2 has a remaining task noting that the share URL still points at Twitter. This updates the generated share link to use the current X domain while preserving the existing share text and encoded shared game URL.

Closes #2

## Validation
- `pnpm lint`
- `pnpm format:check`
- `pnpm test`