### PR TITLE
Use absolute OGP image URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,10 @@
       content="格闘ゲームをはじめとした2人対戦ゲームの読み合いにおいて、ゲーム理論を用いてどの選択肢をどのくらいの確率で選ぶのがおすすめかを計算するアプリです。Use game theory to calculate recommended option probabilities for fighting games and other two-player competitive mind games."
       data-yomi-seo-meta="og:description"
     />
-    <meta property="og:image" content="/ogp.png" />
+    <meta
+      property="og:image"
+      content="https://yomi-nash.terry-u16.net/ogp.png"
+    />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Yomi Nash mix-up analysis preview" />
@@ -45,7 +48,10 @@
       content="格闘ゲームをはじめとした2人対戦ゲームの読み合いにおいて、ゲーム理論を用いてどの選択肢をどのくらいの確率で選ぶのがおすすめかを計算するアプリです。Use game theory to calculate recommended option probabilities for fighting games and other two-player competitive mind games."
       data-yomi-seo-meta="twitter:description"
     />
-    <meta name="twitter:image" content="/ogp.png" />
+    <meta
+      name="twitter:image"
+      content="https://yomi-nash.terry-u16.net/ogp.png"
+    />
     <meta
       name="twitter:image:alt"
       content="Yomi Nash mix-up analysis preview"


### PR DESCRIPTION
## Summary

- Use an absolute production URL for `og:image`
- Use the same absolute production URL for `twitter:image`

## Why

SNS and link preview crawlers are more reliable when image metadata points to an absolute URL instead of a root-relative path.

## Validation

- `pnpm format:check`
- `pnpm build`

Note: the existing Vite chunk size warning still appears during build and is tracked separately as the bundle-splitting follow-up.