### PR TITLE
Shorten share URL payloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "chroma-js": "^3.1.2",
     "d3-scale": "^4.0.2",
     "encoding-japanese": "^2.2.0",
+    "fflate": "^0.8.2",
     "framer-motion": "^12.12.1",
     "glpk.js": "^4.0.2",
     "i18next": "^25.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       encoding-japanese:
         specifier: ^2.2.0
         version: 2.2.0
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.2
       framer-motion:
         specifier: ^12.12.1
         version: 12.12.1(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1179,6 +1182,7 @@ packages:
       }
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   "@rollup/rollup-linux-arm-musleabihf@4.40.2":
     resolution:
@@ -1187,6 +1191,7 @@ packages:
       }
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   "@rollup/rollup-linux-arm64-gnu@4.40.2":
     resolution:
@@ -1195,6 +1200,7 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   "@rollup/rollup-linux-arm64-musl@4.40.2":
     resolution:
@@ -1203,6 +1209,7 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   "@rollup/rollup-linux-loongarch64-gnu@4.40.2":
     resolution:
@@ -1211,6 +1218,7 @@ packages:
       }
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   "@rollup/rollup-linux-powerpc64le-gnu@4.40.2":
     resolution:
@@ -1219,6 +1227,7 @@ packages:
       }
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   "@rollup/rollup-linux-riscv64-gnu@4.40.2":
     resolution:
@@ -1227,6 +1236,7 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   "@rollup/rollup-linux-riscv64-musl@4.40.2":
     resolution:
@@ -1235,6 +1245,7 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   "@rollup/rollup-linux-s390x-gnu@4.40.2":
     resolution:
@@ -1243,6 +1254,7 @@ packages:
       }
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   "@rollup/rollup-linux-x64-gnu@4.40.2":
     resolution:
@@ -1251,6 +1263,7 @@ packages:
       }
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   "@rollup/rollup-linux-x64-musl@4.40.2":
     resolution:
@@ -1259,6 +1272,7 @@ packages:
       }
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   "@rollup/rollup-win32-arm64-msvc@4.40.2":
     resolution:
@@ -2934,6 +2948,12 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.2:
+    resolution:
+      {
+        integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==,
+      }
 
   file-entry-cache@8.0.0:
     resolution:
@@ -7200,6 +7220,8 @@ snapshots:
   fdir@6.4.4(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
+
+  fflate@0.8.2: {}
 
   file-entry-cache@8.0.0:
     dependencies:

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -6,7 +6,7 @@ import { GameResultSchema } from "@/lib/parser/parseGameResult";
 import type { GameInputUI, GameResult } from "@/types/game";
 import { createDefaultGameInputUI } from "@/lib/presets";
 import { DATA_SCHEMA_VERSION, STORAGE_KEYS } from "@/constants/storage";
-import type { ShareEnvelope } from "@/utils/shareCodec";
+import type { ShareEnvelopeV1 } from "@/utils/shareCodec";
 
 interface Props {
   maxWidth: string | undefined;
@@ -17,7 +17,7 @@ const Main: React.FC<Props> = ({ maxWidth }: Props) => {
     try {
       const raw = localStorage.getItem(STORAGE_KEYS.inputUI);
       if (raw) {
-        const parsed = JSON.parse(raw) as ShareEnvelope<unknown>;
+        const parsed = JSON.parse(raw) as ShareEnvelopeV1<unknown>;
         if (parsed.version === DATA_SCHEMA_VERSION) {
           const validated = GameInputUISchema.safeParse(parsed.payload);
           if (validated.success) {
@@ -34,7 +34,7 @@ const Main: React.FC<Props> = ({ maxWidth }: Props) => {
     try {
       const raw = localStorage.getItem(STORAGE_KEYS.result);
       if (raw) {
-        const parsed = JSON.parse(raw) as ShareEnvelope<unknown>;
+        const parsed = JSON.parse(raw) as ShareEnvelopeV1<unknown>;
         if (parsed.version === DATA_SCHEMA_VERSION) {
           const validated = GameResultSchema.safeParse(parsed.payload);
           if (validated.success) {

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -1,4 +1,9 @@
 export const DATA_SCHEMA_VERSION = 1 as const;
+export const SHARE_SCHEMA_VERSION = 2 as const;
+export const SUPPORTED_SHARE_SCHEMA_VERSIONS: readonly number[] = [
+  DATA_SCHEMA_VERSION,
+  SHARE_SCHEMA_VERSION,
+];
 
 export const STORAGE_KEYS = {
   inputUI: "yomiNash:input",

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -118,6 +118,7 @@ const resources = {
         toasts: {
           calcSuccess: "計算が完了しました",
           calcError: "計算に失敗しました",
+          resultCleared: "入力が変更されたため計算結果をクリアしました",
           restore: {
             schemaMismatch: "共有データのバージョンが古いため読み込めません",
             inputError: "入力の復元に失敗しました",
@@ -268,6 +269,7 @@ const resources = {
         toasts: {
           calcSuccess: "Calculation completed",
           calcError: "Calculation failed",
+          resultCleared: "Cleared the result because the input changed",
           restore: {
             schemaMismatch: "The shared data version is too old to load",
             inputError: "Failed to restore the shared input",

--- a/src/lib/parser/__tests__/shareParsing.test.ts
+++ b/src/lib/parser/__tests__/shareParsing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { encodeShareObject } from "@/utils/shareCodec";
+import { encodeLegacyShareObject, encodeShareObject } from "@/utils/shareCodec";
 import { decodeGameInputUI } from "@/lib/parser/parseGameInputUI";
 import { decodeGameResult } from "@/lib/parser/parseGameResult";
 import type { GameInputUI, GameResult } from "@/types/game";
@@ -30,10 +30,27 @@ const sampleResult: GameResult = {
   ],
 };
 
+const sampleInputV2 = {
+  r: ["A", "B"],
+  c: ["X", "Y"],
+  m: [1, 2, 3, 4],
+};
+
 describe("share encoding", () => {
-  it("encodes data with version envelope", () => {
-    const token = encodeShareObject(sampleInputUI);
+  it("encodes compact input data with version envelope", () => {
+    const token = encodeShareObject(sampleInputV2);
     const parsed = decodeGameInputUI(token);
+    expect(parsed).not.toBeNull();
+    if (!parsed) return;
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.data).toEqual(sampleInputUI);
+  });
+
+  it("parses legacy input data", () => {
+    const token = encodeLegacyShareObject(sampleInputUI);
+    const parsed = decodeGameInputUI(token, DATA_SCHEMA_VERSION);
+
     expect(parsed).not.toBeNull();
     if (!parsed) return;
     expect(parsed.ok).toBe(true);
@@ -47,7 +64,7 @@ describe("share encoding", () => {
       payload: sampleInputUI,
     } as const;
     const token = compressToEncodedURIComponent(JSON.stringify(envelope));
-    const parsed = decodeGameInputUI(token);
+    const parsed = decodeGameInputUI(token, SHARE_SCHEMA_VERSION + 1);
 
     expect(parsed).not.toBeNull();
     if (!parsed) return;
@@ -57,8 +74,8 @@ describe("share encoding", () => {
   });
 
   it("parses a legacy valid game result", () => {
-    const token = encodeShareObject(sampleResult, DATA_SCHEMA_VERSION);
-    const parsed = decodeGameResult(token, sampleInputUI);
+    const token = encodeLegacyShareObject(sampleResult);
+    const parsed = decodeGameResult(token, sampleInputUI, DATA_SCHEMA_VERSION);
 
     expect(parsed).not.toBeNull();
     if (!parsed) return;
@@ -69,8 +86,8 @@ describe("share encoding", () => {
 
   it("parses a valid compact game result", () => {
     const token = encodeShareObject({
-      player1Probabilities: [0.5, 0.5],
-      player2Probabilities: [0.25, 0.75],
+      p: [0.5, 0.5],
+      q: [0.25, 0.75],
     });
     const parsed = decodeGameResult(token, sampleInputUI);
 
@@ -91,7 +108,7 @@ describe("share encoding", () => {
       payload: invalidResult,
     } as const;
     const token = compressToEncodedURIComponent(JSON.stringify(envelope));
-    const parsed = decodeGameResult(token, sampleInputUI);
+    const parsed = decodeGameResult(token, sampleInputUI, DATA_SCHEMA_VERSION);
 
     expect(parsed).not.toBeNull();
     if (!parsed) return;

--- a/src/lib/parser/__tests__/shareParsing.test.ts
+++ b/src/lib/parser/__tests__/shareParsing.test.ts
@@ -30,11 +30,11 @@ const sampleResult: GameResult = {
   ],
 };
 
-const sampleInputV2 = {
-  r: ["A", "B"],
-  c: ["X", "Y"],
-  m: [1, 2, 3, 4],
-};
+const sampleInputV2 = [
+  ["A", "B"],
+  ["X", "Y"],
+  [1, 2, 3, 4],
+] as const;
 
 describe("share encoding", () => {
   it("encodes compact input data with version envelope", () => {
@@ -85,10 +85,10 @@ describe("share encoding", () => {
   });
 
   it("parses a valid compact game result", () => {
-    const token = encodeShareObject({
-      p: [0.5, 0.5],
-      q: [0.25, 0.75],
-    });
+    const token = encodeShareObject([
+      [0.5, 0.5],
+      [0.25, 0.75],
+    ]);
     const parsed = decodeGameResult(token, sampleInputUI);
 
     expect(parsed).not.toBeNull();

--- a/src/lib/parser/__tests__/shareParsing.test.ts
+++ b/src/lib/parser/__tests__/shareParsing.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
-import { encodeLegacyShareObject, encodeShareObject } from "@/utils/shareCodec";
+import { describe, expect, it, vi } from "vitest";
+import {
+  decodeShareObject,
+  encodeLegacyShareObject,
+  encodeShareObject,
+} from "@/utils/shareCodec";
 import { decodeGameInputUI } from "@/lib/parser/parseGameInputUI";
 import { decodeGameResult } from "@/lib/parser/parseGameResult";
 import type { GameInputUI, GameResult } from "@/types/game";
@@ -47,6 +51,18 @@ describe("share encoding", () => {
     expect(parsed.data).toEqual(sampleInputUI);
   });
 
+  it("encodes and decodes compact data without browser base64 globals", () => {
+    vi.stubGlobal("btoa", undefined);
+    vi.stubGlobal("atob", undefined);
+
+    try {
+      const token = encodeShareObject(sampleInputV2);
+      expect(decodeShareObject(token)).toEqual(sampleInputV2);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("parses legacy input data", () => {
     const token = encodeLegacyShareObject(sampleInputUI);
     const parsed = decodeGameInputUI(token, DATA_SCHEMA_VERSION);
@@ -56,6 +72,17 @@ describe("share encoding", () => {
     expect(parsed.ok).toBe(true);
     if (!parsed.ok) return;
     expect(parsed.data).toEqual(sampleInputUI);
+  });
+
+  it("rejects malformed legacy input envelopes", () => {
+    const token = compressToEncodedURIComponent(JSON.stringify(sampleInputUI));
+    const parsed = decodeGameInputUI(token, DATA_SCHEMA_VERSION);
+
+    expect(parsed).not.toBeNull();
+    if (!parsed) return;
+    expect(parsed.ok).toBe(false);
+    if (parsed.ok) return;
+    expect(parsed.error).toBe("共有された入力データを復元できませんでした");
   });
 
   it("rejects mismatched schema version for input", () => {

--- a/src/lib/parser/__tests__/shareParsing.test.ts
+++ b/src/lib/parser/__tests__/shareParsing.test.ts
@@ -3,7 +3,7 @@ import { encodeShareObject } from "@/utils/shareCodec";
 import { decodeGameInputUI } from "@/lib/parser/parseGameInputUI";
 import { decodeGameResult } from "@/lib/parser/parseGameResult";
 import type { GameInputUI, GameResult } from "@/types/game";
-import { DATA_SCHEMA_VERSION } from "@/constants/storage";
+import { DATA_SCHEMA_VERSION, SHARE_SCHEMA_VERSION } from "@/constants/storage";
 import { compressToEncodedURIComponent } from "lz-string";
 
 const sampleInputUI: GameInputUI = {
@@ -43,7 +43,7 @@ describe("share encoding", () => {
 
   it("rejects mismatched schema version for input", () => {
     const envelope = {
-      version: DATA_SCHEMA_VERSION + 1,
+      version: SHARE_SCHEMA_VERSION + 1,
       payload: sampleInputUI,
     } as const;
     const token = compressToEncodedURIComponent(JSON.stringify(envelope));
@@ -56,8 +56,22 @@ describe("share encoding", () => {
     expect(parsed.error).toContain("バージョン");
   });
 
-  it("parses a valid game result", () => {
-    const token = encodeShareObject(sampleResult);
+  it("parses a legacy valid game result", () => {
+    const token = encodeShareObject(sampleResult, DATA_SCHEMA_VERSION);
+    const parsed = decodeGameResult(token, sampleInputUI);
+
+    expect(parsed).not.toBeNull();
+    if (!parsed) return;
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.data).toEqual(sampleResult);
+  });
+
+  it("parses a valid compact game result", () => {
+    const token = encodeShareObject({
+      player1Probabilities: [0.5, 0.5],
+      player2Probabilities: [0.25, 0.75],
+    });
     const parsed = decodeGameResult(token, sampleInputUI);
 
     expect(parsed).not.toBeNull();

--- a/src/lib/parser/parseGameInputUI.ts
+++ b/src/lib/parser/parseGameInputUI.ts
@@ -14,11 +14,11 @@ export const GameInputUISchema = z.object({
   payoffMatrix: z.array(z.array(z.string()).min(1)).min(1),
 });
 
-const SharedGameInputV2Schema = z.object({
-  r: z.array(z.string()).min(1),
-  c: z.array(z.string()).min(1),
-  m: z.array(z.number()),
-});
+const SharedGameInputV2Schema = z.tuple([
+  z.array(z.string()).min(1),
+  z.array(z.string()).min(1),
+  z.array(z.number()),
+]);
 
 export function decodeGameInputUI(
   raw: string | null,
@@ -87,19 +87,20 @@ function decodeVersionedGameInputUI(
 }
 
 function decodeSharedGameInputV2(payload: unknown): GameInputUI {
-  const input = SharedGameInputV2Schema.parse(payload);
-  const rowCount = input.r.length;
-  const colCount = input.c.length;
+  const [strategyLabels1, strategyLabels2, payoffMatrix] =
+    SharedGameInputV2Schema.parse(payload);
+  const rowCount = strategyLabels1.length;
+  const colCount = strategyLabels2.length;
 
-  if (input.m.length !== rowCount * colCount) {
+  if (payoffMatrix.length !== rowCount * colCount) {
     throw new Error("利得行列の要素数が行・列のラベル数と一致していません。");
   }
 
   return {
-    strategyLabels1: input.r,
-    strategyLabels2: input.c,
+    strategyLabels1,
+    strategyLabels2,
     payoffMatrix: Array.from({ length: rowCount }, (_, rowIndex) =>
-      input.m
+      payoffMatrix
         .slice(rowIndex * colCount, (rowIndex + 1) * colCount)
         .map((value) => String(value))
     ),

--- a/src/lib/parser/parseGameInputUI.ts
+++ b/src/lib/parser/parseGameInputUI.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { GameInputUI } from "@/types/game";
 import type { Result } from "@/types/result";
-import { decodeShareObject, type ShareEnvelopeV1 } from "@/utils/shareCodec";
+import { decodeLegacyShareObject, decodeShareObject } from "@/utils/shareCodec";
 import {
   DATA_SCHEMA_VERSION,
   SHARE_SCHEMA_VERSION,
@@ -68,7 +68,7 @@ function decodeVersionedGameInputUI(
 ): GameInputUI | null {
   switch (version) {
     case DATA_SCHEMA_VERSION: {
-      const envelope = decodeShareObject<ShareEnvelopeV1<unknown>>(raw);
+      const envelope = decodeLegacyShareObject<unknown>(raw);
       if (!envelope || envelope.version !== DATA_SCHEMA_VERSION) {
         return null;
       }

--- a/src/lib/parser/parseGameInputUI.ts
+++ b/src/lib/parser/parseGameInputUI.ts
@@ -17,7 +17,7 @@ export const GameInputUISchema = z.object({
 const SharedGameInputV2Schema = z.tuple([
   z.array(z.string()).min(1),
   z.array(z.string()).min(1),
-  z.array(z.number()),
+  z.array(z.number().finite()),
 ]);
 
 export function decodeGameInputUI(

--- a/src/lib/parser/parseGameInputUI.ts
+++ b/src/lib/parser/parseGameInputUI.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { GameInputUI } from "@/types/game";
 import type { Result } from "@/types/result";
 import { decodeShareObject } from "@/utils/shareCodec";
-import { DATA_SCHEMA_VERSION } from "@/constants/storage";
+import { SUPPORTED_SHARE_SCHEMA_VERSIONS } from "@/constants/storage";
 
 export const GameInputUISchema = z.object({
   strategyLabels1: z.array(z.string()).min(1),
@@ -20,7 +20,7 @@ export function decodeGameInputUI(
     return { ok: false, error: "共有された入力データを復元できませんでした" };
   }
 
-  if (envelope.version !== DATA_SCHEMA_VERSION) {
+  if (!SUPPORTED_SHARE_SCHEMA_VERSIONS.includes(envelope.version)) {
     return {
       ok: false,
       error: "共有データのバージョンが現在のアプリと一致していません",

--- a/src/lib/parser/parseGameInputUI.ts
+++ b/src/lib/parser/parseGameInputUI.ts
@@ -1,8 +1,12 @@
 import { z } from "zod";
 import type { GameInputUI } from "@/types/game";
 import type { Result } from "@/types/result";
-import { decodeShareObject } from "@/utils/shareCodec";
-import { SUPPORTED_SHARE_SCHEMA_VERSIONS } from "@/constants/storage";
+import { decodeShareObject, type ShareEnvelopeV1 } from "@/utils/shareCodec";
+import {
+  DATA_SCHEMA_VERSION,
+  SHARE_SCHEMA_VERSION,
+  SUPPORTED_SHARE_SCHEMA_VERSIONS,
+} from "@/constants/storage";
 
 export const GameInputUISchema = z.object({
   strategyLabels1: z.array(z.string()).min(1),
@@ -10,17 +14,18 @@ export const GameInputUISchema = z.object({
   payoffMatrix: z.array(z.array(z.string()).min(1)).min(1),
 });
 
+const SharedGameInputV2Schema = z.object({
+  r: z.array(z.string()).min(1),
+  c: z.array(z.string()).min(1),
+  m: z.array(z.number()),
+});
+
 export function decodeGameInputUI(
-  raw: string | null
+  raw: string | null,
+  version: number = SHARE_SCHEMA_VERSION
 ): Result<GameInputUI> | null {
   if (!raw) return null;
-
-  const envelope = decodeShareObject<GameInputUI>(raw);
-  if (!envelope) {
-    return { ok: false, error: "共有された入力データを復元できませんでした" };
-  }
-
-  if (!SUPPORTED_SHARE_SCHEMA_VERSIONS.includes(envelope.version)) {
+  if (!SUPPORTED_SHARE_SCHEMA_VERSIONS.includes(version)) {
     return {
       ok: false,
       error: "共有データのバージョンが現在のアプリと一致していません",
@@ -28,7 +33,13 @@ export function decodeGameInputUI(
   }
 
   try {
-    const input = GameInputUISchema.parse(envelope.payload);
+    const input = decodeVersionedGameInputUI(raw, version);
+    if (!input) {
+      return {
+        ok: false,
+        error: "共有された入力データを復元できませんでした",
+      };
+    }
 
     // バリデーション：行列のサイズがラベル数と一致
     const rows = input.payoffMatrix.length;
@@ -49,4 +60,48 @@ export function decodeGameInputUI(
     const message = e instanceof Error ? e.message : String(e);
     return { ok: false, error: message };
   }
+}
+
+function decodeVersionedGameInputUI(
+  raw: string,
+  version: number
+): GameInputUI | null {
+  switch (version) {
+    case DATA_SCHEMA_VERSION: {
+      const envelope = decodeShareObject<ShareEnvelopeV1<unknown>>(raw);
+      if (!envelope || envelope.version !== DATA_SCHEMA_VERSION) {
+        return null;
+      }
+      return GameInputUISchema.parse(envelope.payload);
+    }
+    case SHARE_SCHEMA_VERSION: {
+      const payload = decodeShareObject<unknown>(raw);
+      if (payload === null) {
+        return null;
+      }
+      return decodeSharedGameInputV2(payload);
+    }
+    default:
+      return null;
+  }
+}
+
+function decodeSharedGameInputV2(payload: unknown): GameInputUI {
+  const input = SharedGameInputV2Schema.parse(payload);
+  const rowCount = input.r.length;
+  const colCount = input.c.length;
+
+  if (input.m.length !== rowCount * colCount) {
+    throw new Error("利得行列の要素数が行・列のラベル数と一致していません。");
+  }
+
+  return {
+    strategyLabels1: input.r,
+    strategyLabels2: input.c,
+    payoffMatrix: Array.from({ length: rowCount }, (_, rowIndex) =>
+      input.m
+        .slice(rowIndex * colCount, (rowIndex + 1) * colCount)
+        .map((value) => String(value))
+    ),
+  };
 }

--- a/src/lib/parser/parseGameResult.ts
+++ b/src/lib/parser/parseGameResult.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { GameResult, GameInputUI } from "@/types/game";
 import type { Result } from "@/types/result";
-import { decodeShareObject, type ShareEnvelopeV1 } from "@/utils/shareCodec";
+import { decodeLegacyShareObject, decodeShareObject } from "@/utils/shareCodec";
 import {
   DATA_SCHEMA_VERSION,
   SHARE_SCHEMA_VERSION,
@@ -41,7 +41,7 @@ export function decodeGameResult(
   try {
     switch (version) {
       case DATA_SCHEMA_VERSION: {
-        const envelope = decodeShareObject<ShareEnvelopeV1<unknown>>(raw);
+        const envelope = decodeLegacyShareObject<unknown>(raw);
         if (!envelope || envelope.version !== DATA_SCHEMA_VERSION) {
           return {
             ok: false,

--- a/src/lib/parser/parseGameResult.ts
+++ b/src/lib/parser/parseGameResult.ts
@@ -20,10 +20,10 @@ export const GameResultSchema = z.object({
   payoffMatrix: z.array(z.array(z.number())),
 });
 
-const SharedGameResultV2Schema = z.object({
-  p: z.array(z.number().min(0).max(1)),
-  q: z.array(z.number().min(0).max(1)),
-});
+const SharedGameResultV2Schema = z.tuple([
+  z.array(z.number().min(0).max(1)),
+  z.array(z.number().min(0).max(1)),
+]);
 
 export function decodeGameResult(
   raw: string | null,
@@ -112,11 +112,12 @@ function decodeSharedGameResultV2(
   payload: unknown,
   inputUI: GameInputUI
 ): Result<GameResult> {
-  const probabilities = SharedGameResultV2Schema.parse(payload);
+  const [player1Probabilities, player2Probabilities] =
+    SharedGameResultV2Schema.parse(payload);
 
   if (
-    probabilities.p.length !== inputUI.strategyLabels1.length ||
-    probabilities.q.length !== inputUI.strategyLabels2.length
+    player1Probabilities.length !== inputUI.strategyLabels1.length ||
+    player2Probabilities.length !== inputUI.strategyLabels2.length
   ) {
     return {
       ok: false,
@@ -137,11 +138,11 @@ function decodeSharedGameResultV2(
     data: {
       player1Strategy: inputUI.strategyLabels1.map((label, index) => ({
         label,
-        probability: probabilities.p[index],
+        probability: player1Probabilities[index],
       })),
       player2Strategy: inputUI.strategyLabels2.map((label, index) => ({
         label,
-        probability: probabilities.q[index],
+        probability: player2Probabilities[index],
       })),
       payoffMatrix: inputResult.data.payoffMatrix,
     },

--- a/src/lib/parser/parseGameResult.ts
+++ b/src/lib/parser/parseGameResult.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
 import type { GameResult, GameInputUI } from "@/types/game";
 import type { Result } from "@/types/result";
-import { decodeShareObject } from "@/utils/shareCodec";
+import { decodeShareObject, type ShareEnvelopeV1 } from "@/utils/shareCodec";
 import {
+  DATA_SCHEMA_VERSION,
   SHARE_SCHEMA_VERSION,
   SUPPORTED_SHARE_SCHEMA_VERSIONS,
 } from "@/constants/storage";
@@ -20,22 +21,17 @@ export const GameResultSchema = z.object({
 });
 
 const SharedGameResultV2Schema = z.object({
-  player1Probabilities: z.array(z.number().min(0).max(1)),
-  player2Probabilities: z.array(z.number().min(0).max(1)),
+  p: z.array(z.number().min(0).max(1)),
+  q: z.array(z.number().min(0).max(1)),
 });
 
 export function decodeGameResult(
   raw: string | null,
-  inputUI: GameInputUI
+  inputUI: GameInputUI,
+  version: number = SHARE_SCHEMA_VERSION
 ): Result<GameResult> | null {
   if (!raw) return null;
-
-  const envelope = decodeShareObject<unknown>(raw);
-  if (!envelope) {
-    return { ok: false, error: "共有された結果データを復元できませんでした" };
-  }
-
-  if (!SUPPORTED_SHARE_SCHEMA_VERSIONS.includes(envelope.version)) {
+  if (!SUPPORTED_SHARE_SCHEMA_VERSIONS.includes(version)) {
     return {
       ok: false,
       error: "共有データのバージョンが現在のアプリと一致していません",
@@ -43,44 +39,73 @@ export function decodeGameResult(
   }
 
   try {
-    if (envelope.version >= SHARE_SCHEMA_VERSION) {
-      return decodeSharedGameResultV2(envelope.payload, inputUI);
-    }
-
-    const result = GameResultSchema.parse(envelope.payload);
-
-    // バリデーション：ラベルの一致
-    const labels1 = new Set(inputUI.strategyLabels1);
-    const labels2 = new Set(inputUI.strategyLabels2);
-
-    for (const { label } of result.player1Strategy) {
-      if (!labels1.has(label)) {
-        return { ok: false, error: `不正なplayer1のラベル: ${label}` };
+    switch (version) {
+      case DATA_SCHEMA_VERSION: {
+        const envelope = decodeShareObject<ShareEnvelopeV1<unknown>>(raw);
+        if (!envelope || envelope.version !== DATA_SCHEMA_VERSION) {
+          return {
+            ok: false,
+            error: "共有された結果データを復元できませんでした",
+          };
+        }
+        return decodeLegacyGameResult(envelope.payload, inputUI);
       }
-    }
-
-    for (const { label } of result.player2Strategy) {
-      if (!labels2.has(label)) {
-        return { ok: false, error: `不正なplayer2のラベル: ${label}` };
+      case SHARE_SCHEMA_VERSION: {
+        const payload = decodeShareObject<unknown>(raw);
+        if (payload === null) {
+          return {
+            ok: false,
+            error: "共有された結果データを復元できませんでした",
+          };
+        }
+        return decodeSharedGameResultV2(payload, inputUI);
       }
+      default:
+        return {
+          ok: false,
+          error: "共有データのバージョンが現在のアプリと一致していません",
+        };
     }
-
-    // バリデーション：payoffMatrixのサイズ
-    if (
-      result.payoffMatrix.length !== inputUI.strategyLabels1.length ||
-      result.payoffMatrix[0]?.length !== inputUI.strategyLabels2.length
-    ) {
-      return {
-        ok: false,
-        error: "GameResultのpayoffMatrixのサイズがGameInputUIと一致しません",
-      };
-    }
-
-    return { ok: true, data: result };
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
     return { ok: false, error: message };
   }
+}
+
+function decodeLegacyGameResult(
+  payload: unknown,
+  inputUI: GameInputUI
+): Result<GameResult> {
+  const result = GameResultSchema.parse(payload);
+
+  // バリデーション：ラベルの一致
+  const labels1 = new Set(inputUI.strategyLabels1);
+  const labels2 = new Set(inputUI.strategyLabels2);
+
+  for (const { label } of result.player1Strategy) {
+    if (!labels1.has(label)) {
+      return { ok: false, error: `不正なplayer1のラベル: ${label}` };
+    }
+  }
+
+  for (const { label } of result.player2Strategy) {
+    if (!labels2.has(label)) {
+      return { ok: false, error: `不正なplayer2のラベル: ${label}` };
+    }
+  }
+
+  // バリデーション：payoffMatrixのサイズ
+  if (
+    result.payoffMatrix.length !== inputUI.strategyLabels1.length ||
+    result.payoffMatrix[0]?.length !== inputUI.strategyLabels2.length
+  ) {
+    return {
+      ok: false,
+      error: "GameResultのpayoffMatrixのサイズがGameInputUIと一致しません",
+    };
+  }
+
+  return { ok: true, data: result };
 }
 
 function decodeSharedGameResultV2(
@@ -90,9 +115,8 @@ function decodeSharedGameResultV2(
   const probabilities = SharedGameResultV2Schema.parse(payload);
 
   if (
-    probabilities.player1Probabilities.length !==
-      inputUI.strategyLabels1.length ||
-    probabilities.player2Probabilities.length !== inputUI.strategyLabels2.length
+    probabilities.p.length !== inputUI.strategyLabels1.length ||
+    probabilities.q.length !== inputUI.strategyLabels2.length
   ) {
     return {
       ok: false,
@@ -113,11 +137,11 @@ function decodeSharedGameResultV2(
     data: {
       player1Strategy: inputUI.strategyLabels1.map((label, index) => ({
         label,
-        probability: probabilities.player1Probabilities[index],
+        probability: probabilities.p[index],
       })),
       player2Strategy: inputUI.strategyLabels2.map((label, index) => ({
         label,
-        probability: probabilities.player2Probabilities[index],
+        probability: probabilities.q[index],
       })),
       payoffMatrix: inputResult.data.payoffMatrix,
     },

--- a/src/lib/parser/parseGameResult.ts
+++ b/src/lib/parser/parseGameResult.ts
@@ -2,7 +2,11 @@ import { z } from "zod";
 import type { GameResult, GameInputUI } from "@/types/game";
 import type { Result } from "@/types/result";
 import { decodeShareObject } from "@/utils/shareCodec";
-import { DATA_SCHEMA_VERSION } from "@/constants/storage";
+import {
+  SHARE_SCHEMA_VERSION,
+  SUPPORTED_SHARE_SCHEMA_VERSIONS,
+} from "@/constants/storage";
+import { parseGameInputUI } from "@/utils/parseGameInput";
 
 const MixedStrategyEntrySchema = z.object({
   label: z.string(),
@@ -15,18 +19,23 @@ export const GameResultSchema = z.object({
   payoffMatrix: z.array(z.array(z.number())),
 });
 
+const SharedGameResultV2Schema = z.object({
+  player1Probabilities: z.array(z.number().min(0).max(1)),
+  player2Probabilities: z.array(z.number().min(0).max(1)),
+});
+
 export function decodeGameResult(
   raw: string | null,
   inputUI: GameInputUI
 ): Result<GameResult> | null {
   if (!raw) return null;
 
-  const envelope = decodeShareObject<GameResult>(raw);
+  const envelope = decodeShareObject<unknown>(raw);
   if (!envelope) {
     return { ok: false, error: "共有された結果データを復元できませんでした" };
   }
 
-  if (envelope.version !== DATA_SCHEMA_VERSION) {
+  if (!SUPPORTED_SHARE_SCHEMA_VERSIONS.includes(envelope.version)) {
     return {
       ok: false,
       error: "共有データのバージョンが現在のアプリと一致していません",
@@ -34,6 +43,10 @@ export function decodeGameResult(
   }
 
   try {
+    if (envelope.version >= SHARE_SCHEMA_VERSION) {
+      return decodeSharedGameResultV2(envelope.payload, inputUI);
+    }
+
     const result = GameResultSchema.parse(envelope.payload);
 
     // バリデーション：ラベルの一致
@@ -68,4 +81,45 @@ export function decodeGameResult(
     const message = e instanceof Error ? e.message : String(e);
     return { ok: false, error: message };
   }
+}
+
+function decodeSharedGameResultV2(
+  payload: unknown,
+  inputUI: GameInputUI
+): Result<GameResult> {
+  const probabilities = SharedGameResultV2Schema.parse(payload);
+
+  if (
+    probabilities.player1Probabilities.length !==
+      inputUI.strategyLabels1.length ||
+    probabilities.player2Probabilities.length !== inputUI.strategyLabels2.length
+  ) {
+    return {
+      ok: false,
+      error: "共有された確率の数が行・列のラベル数と一致していません",
+    };
+  }
+
+  const inputResult = parseGameInputUI(inputUI);
+  if (!inputResult.ok) {
+    return {
+      ok: false,
+      error: "共有された入力データから利得行列を復元できませんでした",
+    };
+  }
+
+  return {
+    ok: true,
+    data: {
+      player1Strategy: inputUI.strategyLabels1.map((label, index) => ({
+        label,
+        probability: probabilities.player1Probabilities[index],
+      })),
+      player2Strategy: inputUI.strategyLabels2.map((label, index) => ({
+        label,
+        probability: probabilities.player2Probabilities[index],
+      })),
+      payoffMatrix: inputResult.data.payoffMatrix,
+    },
+  };
 }

--- a/src/lib/persistence/__tests__/restoreFromLocation.test.ts
+++ b/src/lib/persistence/__tests__/restoreFromLocation.test.ts
@@ -28,11 +28,11 @@ const validResult: GameResult = {
   ],
 };
 
-const validInputV2 = {
-  r: ["A", "B"],
-  c: ["X", "Y"],
-  m: [1, 2, 3, 4],
-};
+const validInputV2 = [
+  ["A", "B"],
+  ["X", "Y"],
+  [1, 2, 3, 4],
+] as const;
 
 describe("restoreFromLocation", () => {
   it("returns none when no share data is present", () => {
@@ -52,14 +52,7 @@ describe("restoreFromLocation", () => {
   it("surfaces input decode errors", () => {
     const params = new URLSearchParams();
     params.set("schemaVersion", String(SHARE_SCHEMA_VERSION));
-    params.set(
-      "i",
-      encodeShareObject({
-        r: ["A"],
-        c: ["X"],
-        m: [1, 2],
-      })
-    );
+    params.set("i", encodeShareObject([["A"], ["X"], [1, 2]]));
 
     const outcome = restoreFromLocation(`?${params.toString()}`);
     expect(outcome.status).toBe("input-error");
@@ -88,10 +81,10 @@ describe("restoreFromLocation", () => {
     params.set("i", encodeShareObject(validInputV2));
     params.set(
       "r",
-      encodeShareObject({
-        p: [0.5, 0.5],
-        q: [0.25, 0.75],
-      })
+      encodeShareObject([
+        [0.5, 0.5],
+        [0.25, 0.75],
+      ])
     );
 
     expect(restoreFromLocation(`?${params.toString()}`)).toEqual({

--- a/src/lib/persistence/__tests__/restoreFromLocation.test.ts
+++ b/src/lib/persistence/__tests__/restoreFromLocation.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { restoreFromLocation } from "@/lib/persistence/restoreFromLocation";
 import { encodeShareObject } from "@/utils/shareCodec";
 import type { GameInputUI, GameResult } from "@/types/game";
-import { DATA_SCHEMA_VERSION } from "@/constants/storage";
+import { DATA_SCHEMA_VERSION, SHARE_SCHEMA_VERSION } from "@/constants/storage";
 
 const validInput: GameInputUI = {
   strategyLabels1: ["A", "B"],
@@ -35,7 +35,7 @@ describe("restoreFromLocation", () => {
 
   it("detects schema version mismatches", () => {
     const params = new URLSearchParams();
-    params.set("schemaVersion", String(DATA_SCHEMA_VERSION + 1));
+    params.set("schemaVersion", String(SHARE_SCHEMA_VERSION + 1));
     params.set("gameInput", encodeShareObject(validInput));
 
     expect(restoreFromLocation(`?${params.toString()}`)).toEqual({
@@ -51,7 +51,7 @@ describe("restoreFromLocation", () => {
     } satisfies GameInputUI;
 
     const params = new URLSearchParams();
-    params.set("schemaVersion", String(DATA_SCHEMA_VERSION));
+    params.set("schemaVersion", String(SHARE_SCHEMA_VERSION));
     params.set("gameInput", encodeShareObject(invalidInput));
 
     const outcome = restoreFromLocation(`?${params.toString()}`);
@@ -65,7 +65,7 @@ describe("restoreFromLocation", () => {
 
   it("restores input when result is absent", () => {
     const params = new URLSearchParams();
-    params.set("schemaVersion", String(DATA_SCHEMA_VERSION));
+    params.set("schemaVersion", String(SHARE_SCHEMA_VERSION));
     params.set("gameInput", encodeShareObject(validInput));
 
     expect(restoreFromLocation(`?${params.toString()}`)).toEqual({
@@ -77,9 +77,15 @@ describe("restoreFromLocation", () => {
 
   it("restores input and result when both are valid", () => {
     const params = new URLSearchParams();
-    params.set("schemaVersion", String(DATA_SCHEMA_VERSION));
+    params.set("schemaVersion", String(SHARE_SCHEMA_VERSION));
     params.set("gameInput", encodeShareObject(validInput));
-    params.set("gameResult", encodeShareObject(validResult));
+    params.set(
+      "gameResult",
+      encodeShareObject({
+        player1Probabilities: [0.5, 0.5],
+        player2Probabilities: [0.25, 0.75],
+      })
+    );
 
     expect(restoreFromLocation(`?${params.toString()}`)).toEqual({
       status: "success",
@@ -96,8 +102,11 @@ describe("restoreFromLocation", () => {
 
     const params = new URLSearchParams();
     params.set("schemaVersion", String(DATA_SCHEMA_VERSION));
-    params.set("gameInput", encodeShareObject(validInput));
-    params.set("gameResult", encodeShareObject(invalidResult));
+    params.set("gameInput", encodeShareObject(validInput, DATA_SCHEMA_VERSION));
+    params.set(
+      "gameResult",
+      encodeShareObject(invalidResult, DATA_SCHEMA_VERSION)
+    );
 
     const outcome = restoreFromLocation(`?${params.toString()}`);
     expect(outcome.status).toBe("success");

--- a/src/lib/persistence/__tests__/restoreFromLocation.test.ts
+++ b/src/lib/persistence/__tests__/restoreFromLocation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { restoreFromLocation } from "@/lib/persistence/restoreFromLocation";
-import { encodeShareObject } from "@/utils/shareCodec";
+import { encodeLegacyShareObject, encodeShareObject } from "@/utils/shareCodec";
 import type { GameInputUI, GameResult } from "@/types/game";
 import { DATA_SCHEMA_VERSION, SHARE_SCHEMA_VERSION } from "@/constants/storage";
 
@@ -28,6 +28,12 @@ const validResult: GameResult = {
   ],
 };
 
+const validInputV2 = {
+  r: ["A", "B"],
+  c: ["X", "Y"],
+  m: [1, 2, 3, 4],
+};
+
 describe("restoreFromLocation", () => {
   it("returns none when no share data is present", () => {
     expect(restoreFromLocation("")).toEqual({ status: "none" });
@@ -36,7 +42,7 @@ describe("restoreFromLocation", () => {
   it("detects schema version mismatches", () => {
     const params = new URLSearchParams();
     params.set("schemaVersion", String(SHARE_SCHEMA_VERSION + 1));
-    params.set("gameInput", encodeShareObject(validInput));
+    params.set("i", encodeShareObject(validInputV2));
 
     expect(restoreFromLocation(`?${params.toString()}`)).toEqual({
       status: "schema-version-mismatch",
@@ -44,21 +50,22 @@ describe("restoreFromLocation", () => {
   });
 
   it("surfaces input decode errors", () => {
-    const invalidInput = {
-      strategyLabels1: ["A"],
-      strategyLabels2: ["X"],
-      payoffMatrix: [["1", "2"]],
-    } satisfies GameInputUI;
-
     const params = new URLSearchParams();
     params.set("schemaVersion", String(SHARE_SCHEMA_VERSION));
-    params.set("gameInput", encodeShareObject(invalidInput));
+    params.set(
+      "i",
+      encodeShareObject({
+        r: ["A"],
+        c: ["X"],
+        m: [1, 2],
+      })
+    );
 
     const outcome = restoreFromLocation(`?${params.toString()}`);
     expect(outcome.status).toBe("input-error");
     if (outcome.status === "input-error") {
       expect(outcome.message).toBe(
-        "表のサイズと行・列のラベル数が一致していません。"
+        "利得行列の要素数が行・列のラベル数と一致していません。"
       );
     }
   });
@@ -66,7 +73,7 @@ describe("restoreFromLocation", () => {
   it("restores input when result is absent", () => {
     const params = new URLSearchParams();
     params.set("schemaVersion", String(SHARE_SCHEMA_VERSION));
-    params.set("gameInput", encodeShareObject(validInput));
+    params.set("i", encodeShareObject(validInputV2));
 
     expect(restoreFromLocation(`?${params.toString()}`)).toEqual({
       status: "success",
@@ -78,12 +85,12 @@ describe("restoreFromLocation", () => {
   it("restores input and result when both are valid", () => {
     const params = new URLSearchParams();
     params.set("schemaVersion", String(SHARE_SCHEMA_VERSION));
-    params.set("gameInput", encodeShareObject(validInput));
+    params.set("i", encodeShareObject(validInputV2));
     params.set(
-      "gameResult",
+      "r",
       encodeShareObject({
-        player1Probabilities: [0.5, 0.5],
-        player2Probabilities: [0.25, 0.75],
+        p: [0.5, 0.5],
+        q: [0.25, 0.75],
       })
     );
 
@@ -102,11 +109,8 @@ describe("restoreFromLocation", () => {
 
     const params = new URLSearchParams();
     params.set("schemaVersion", String(DATA_SCHEMA_VERSION));
-    params.set("gameInput", encodeShareObject(validInput, DATA_SCHEMA_VERSION));
-    params.set(
-      "gameResult",
-      encodeShareObject(invalidResult, DATA_SCHEMA_VERSION)
-    );
+    params.set("gameInput", encodeLegacyShareObject(validInput));
+    params.set("gameResult", encodeLegacyShareObject(invalidResult));
 
     const outcome = restoreFromLocation(`?${params.toString()}`);
     expect(outcome.status).toBe("success");

--- a/src/lib/persistence/__tests__/restoreFromLocation.test.ts
+++ b/src/lib/persistence/__tests__/restoreFromLocation.test.ts
@@ -75,6 +75,20 @@ describe("restoreFromLocation", () => {
     });
   });
 
+  it("ignores short params when restoring a legacy share URL", () => {
+    const params = new URLSearchParams();
+    params.set("i", "not-v2-input");
+    params.set("r", "not-v2-result");
+    params.set("gameInput", encodeLegacyShareObject(validInput));
+    params.set("gameResult", encodeLegacyShareObject(validResult));
+
+    expect(restoreFromLocation(`?${params.toString()}`)).toEqual({
+      status: "success",
+      inputUI: validInput,
+      result: validResult,
+    });
+  });
+
   it("restores input and result when both are valid", () => {
     const params = new URLSearchParams();
     params.set("schemaVersion", String(SHARE_SCHEMA_VERSION));

--- a/src/lib/persistence/restoreFromLocation.ts
+++ b/src/lib/persistence/restoreFromLocation.ts
@@ -1,4 +1,7 @@
-import { SUPPORTED_SHARE_SCHEMA_VERSIONS } from "@/constants/storage";
+import {
+  DATA_SCHEMA_VERSION,
+  SUPPORTED_SHARE_SCHEMA_VERSIONS,
+} from "@/constants/storage";
 import type { GameInputUI, GameResult } from "@/types/game";
 import type { Result } from "@/types/result";
 import { decodeGameInputUI } from "@/lib/parser/parseGameInputUI";
@@ -23,20 +26,21 @@ export function restoreFromLocation(
 ): RestoreFromLocationOutcome {
   const searchParams = new URLSearchParams(search);
   const versionParam = searchParams.get("schemaVersion");
+  let version: number = DATA_SCHEMA_VERSION;
 
   if (versionParam !== null) {
-    const version = Number.parseInt(versionParam, 10);
+    version = Number.parseInt(versionParam, 10);
     if (!SUPPORTED_SHARE_SCHEMA_VERSIONS.includes(version)) {
       return { status: "schema-version-mismatch" };
     }
   }
 
-  const rawInput = searchParams.get("gameInput");
+  const rawInput = searchParams.get("i") ?? searchParams.get("gameInput");
   if (!rawInput) {
     return { status: "none" };
   }
 
-  const inputResult = decodeGameInputUI(rawInput);
+  const inputResult = decodeGameInputUI(rawInput, version);
   if (!inputResult) {
     return { status: "none" };
   }
@@ -48,7 +52,7 @@ export function restoreFromLocation(
     };
   }
 
-  const rawResult = searchParams.get("gameResult");
+  const rawResult = searchParams.get("r") ?? searchParams.get("gameResult");
   if (!rawResult) {
     return {
       status: "success",
@@ -57,7 +61,7 @@ export function restoreFromLocation(
     };
   }
 
-  const resultResult = decodeGameResult(rawResult, inputResult.data);
+  const resultResult = decodeGameResult(rawResult, inputResult.data, version);
   if (!resultResult) {
     return {
       status: "success",

--- a/src/lib/persistence/restoreFromLocation.ts
+++ b/src/lib/persistence/restoreFromLocation.ts
@@ -1,4 +1,4 @@
-import { DATA_SCHEMA_VERSION } from "@/constants/storage";
+import { SUPPORTED_SHARE_SCHEMA_VERSIONS } from "@/constants/storage";
 import type { GameInputUI, GameResult } from "@/types/game";
 import type { Result } from "@/types/result";
 import { decodeGameInputUI } from "@/lib/parser/parseGameInputUI";
@@ -24,11 +24,11 @@ export function restoreFromLocation(
   const searchParams = new URLSearchParams(search);
   const versionParam = searchParams.get("schemaVersion");
 
-  if (
-    versionParam !== null &&
-    Number.parseInt(versionParam, 10) !== DATA_SCHEMA_VERSION
-  ) {
-    return { status: "schema-version-mismatch" };
+  if (versionParam !== null) {
+    const version = Number.parseInt(versionParam, 10);
+    if (!SUPPORTED_SHARE_SCHEMA_VERSIONS.includes(version)) {
+      return { status: "schema-version-mismatch" };
+    }
   }
 
   const rawInput = searchParams.get("gameInput");

--- a/src/lib/persistence/restoreFromLocation.ts
+++ b/src/lib/persistence/restoreFromLocation.ts
@@ -1,5 +1,6 @@
 import {
   DATA_SCHEMA_VERSION,
+  SHARE_SCHEMA_VERSION,
   SUPPORTED_SHARE_SCHEMA_VERSIONS,
 } from "@/constants/storage";
 import type { GameInputUI, GameResult } from "@/types/game";
@@ -35,7 +36,10 @@ export function restoreFromLocation(
     }
   }
 
-  const rawInput = searchParams.get("i") ?? searchParams.get("gameInput");
+  const rawInput =
+    version === SHARE_SCHEMA_VERSION
+      ? searchParams.get("i")
+      : searchParams.get("gameInput");
   if (!rawInput) {
     return { status: "none" };
   }
@@ -52,7 +56,10 @@ export function restoreFromLocation(
     };
   }
 
-  const rawResult = searchParams.get("r") ?? searchParams.get("gameResult");
+  const rawResult =
+    version === SHARE_SCHEMA_VERSION
+      ? searchParams.get("r")
+      : searchParams.get("gameResult");
   if (!rawResult) {
     return {
       status: "success",

--- a/src/pages/Home/__tests__/Home.localStorage.test.tsx
+++ b/src/pages/Home/__tests__/Home.localStorage.test.tsx
@@ -21,6 +21,11 @@ type LayoutContextGetter = () => LayoutContext;
 const mockOutletContext = vi.fn<LayoutContextGetter>(() => {
   throw new Error("mockOutletContext not configured");
 });
+let capturedPayoffTableProps:
+  | {
+      setInputUI: Dispatch<SetStateAction<GameInputUI>>;
+    }
+  | undefined;
 const toasterCreate = vi.fn();
 
 vi.mock("@chakra-ui/react", () => ({
@@ -28,7 +33,10 @@ vi.mock("@chakra-ui/react", () => ({
 }));
 
 vi.mock("@/pages/Home/PayoffTable/PayoffTable", () => ({
-  default: () => null,
+  default: (props: { setInputUI: Dispatch<SetStateAction<GameInputUI>> }) => {
+    capturedPayoffTableProps = props;
+    return null;
+  },
 }));
 
 vi.mock("@/pages/Home/ResultDisplay/ResultDisplay", () => ({
@@ -84,6 +92,7 @@ beforeEach(() => {
     throw new Error("mockOutletContext not configured");
   });
   toasterCreate.mockReset();
+  capturedPayoffTableProps = undefined;
   window.history.replaceState(null, "", "/");
 });
 
@@ -172,5 +181,60 @@ describe("Home localStorage persistence", () => {
       STORAGE_KEYS.result
     );
     expect(localStorageMock.store.has(STORAGE_KEYS.result)).toBe(false);
+  });
+
+  it("clears stale results and notifies when the input is edited", async () => {
+    const setInputUI = vi.fn();
+    const setResult = vi.fn();
+    mockOutletContext.mockReturnValue({
+      inputUI: sampleInputUI,
+      setInputUI,
+      result: sampleResult,
+      setResult,
+    });
+
+    await renderHome();
+
+    expect(capturedPayoffTableProps).toBeDefined();
+    act(() => {
+      capturedPayoffTableProps?.setInputUI((prev) => ({
+        ...prev,
+        payoffMatrix: [
+          ["9", "2"],
+          ["3", "4"],
+        ],
+      }));
+    });
+
+    expect(setInputUI).toHaveBeenCalledWith(expect.any(Function));
+    expect(setResult).toHaveBeenCalledWith(null);
+    expect(toasterCreate).toHaveBeenCalledWith({
+      title: "home.toasts.resultCleared",
+      type: "warning",
+    });
+  });
+
+  it("does not notify when editing input without a result", async () => {
+    const setInputUI = vi.fn();
+    const setResult = vi.fn();
+    mockOutletContext.mockReturnValue({
+      inputUI: sampleInputUI,
+      setInputUI,
+      result: null,
+      setResult,
+    });
+
+    await renderHome();
+
+    act(() => {
+      capturedPayoffTableProps?.setInputUI(sampleInputUI);
+    });
+
+    expect(setInputUI).toHaveBeenCalledWith(sampleInputUI);
+    expect(setResult).not.toHaveBeenCalled();
+    expect(toasterCreate).not.toHaveBeenCalledWith({
+      title: "home.toasts.resultCleared",
+      type: "warning",
+    });
   });
 });

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -5,6 +5,7 @@ import type { GameInput, GameInputUI, GameResult } from "@/types/game";
 import { solveGame } from "@/utils/solveGameInput";
 import { Stack } from "@chakra-ui/react";
 import { lazy, Suspense, useCallback, useEffect, useRef } from "react";
+import type { SetStateAction } from "react";
 import { restoreFromLocation } from "@/lib/persistence/restoreFromLocation";
 import { persistToStorage } from "@/lib/persistence/persistToStorage";
 import { useOutletContext } from "react-router-dom";
@@ -47,6 +48,20 @@ const Home: React.FC = () => {
       }
     },
     [setResult, t]
+  );
+
+  const handleInputChange = useCallback(
+    (action: SetStateAction<GameInputUI>) => {
+      setInputUI(action);
+      if (result) {
+        setResult(null);
+        toaster.create({
+          title: t("home.toasts.resultCleared"),
+          type: "warning",
+        });
+      }
+    },
+    [result, setInputUI, setResult, t]
   );
 
   // 初回マウント時にURL から復元（localStorage は Main 初期化で処理済み）
@@ -107,10 +122,10 @@ const Home: React.FC = () => {
 
   return (
     <Stack gap={4} mb={4}>
-      <PayoffTable inputUI={inputUI} setInputUI={setInputUI} />
+      <PayoffTable inputUI={inputUI} setInputUI={handleInputChange} />
       <TableControls
         inputUI={inputUI}
-        setInputUI={setInputUI}
+        setInputUI={handleInputChange}
         onCalculate={handleCalculate}
         result={result}
         onReset={() => setResult(null)}

--- a/src/utils/__tests__/createShareUrl.test.ts
+++ b/src/utils/__tests__/createShareUrl.test.ts
@@ -40,7 +40,7 @@ describe("createShareUrl", () => {
     expect(parsedUrl.searchParams.get("schemaVersion")).toBe(
       String(SHARE_SCHEMA_VERSION)
     );
-    expect(parsedUrl.searchParams.get("gameInput")).toBeTruthy();
+    expect(parsedUrl.searchParams.get("i")).toBeTruthy();
   });
 
   it("encodes the schema version and game input", () => {
@@ -48,26 +48,31 @@ describe("createShareUrl", () => {
     const params = new URL(url).searchParams;
 
     expect(params.get("schemaVersion")).toBe(String(SHARE_SCHEMA_VERSION));
-    expect(params.get("gameInput")).toBeTruthy();
-    expect(params.get("gameResult")).toBeNull();
+    expect(params.get("i")).toBeTruthy();
+    expect(params.get("gameInput")).toBeNull();
+    expect(params.get("r")).toBeNull();
   });
 
-  it("includes only result probabilities when provided", () => {
+  it("includes compact input and result payloads when provided", () => {
     const url = createShareUrl(sampleInput, {
       baseUrl: "https://example.com/app",
       result: sampleResult,
     });
     const params = new URL(url).searchParams;
-    const rawResult = params.get("gameResult");
+    const rawInput = params.get("i");
+    const rawResult = params.get("r");
 
+    expect(rawInput).toBeTruthy();
     expect(rawResult).toBeTruthy();
-    if (!rawResult) return;
+    if (!rawInput || !rawResult) return;
+    expect(decodeShareObject(rawInput)).toEqual({
+      r: ["A", "B"],
+      c: ["X", "Y"],
+      m: [1, 2, 3, 4],
+    });
     expect(decodeShareObject(rawResult)).toEqual({
-      version: SHARE_SCHEMA_VERSION,
-      payload: {
-        player1Probabilities: [0.5, 0.5],
-        player2Probabilities: [0.25, 0.75],
-      },
+      p: [0.5, 0.5],
+      q: [0.25, 0.75],
     });
   });
 
@@ -78,6 +83,6 @@ describe("createShareUrl", () => {
     });
     const params = new URL(url).searchParams;
 
-    expect(params.get("gameResult")).toBeNull();
+    expect(params.get("r")).toBeNull();
   });
 });

--- a/src/utils/__tests__/createShareUrl.test.ts
+++ b/src/utils/__tests__/createShareUrl.test.ts
@@ -65,15 +65,15 @@ describe("createShareUrl", () => {
     expect(rawInput).toBeTruthy();
     expect(rawResult).toBeTruthy();
     if (!rawInput || !rawResult) return;
-    expect(decodeShareObject(rawInput)).toEqual({
-      r: ["A", "B"],
-      c: ["X", "Y"],
-      m: [1, 2, 3, 4],
-    });
-    expect(decodeShareObject(rawResult)).toEqual({
-      p: [0.5, 0.5],
-      q: [0.25, 0.75],
-    });
+    expect(decodeShareObject(rawInput)).toEqual([
+      ["A", "B"],
+      ["X", "Y"],
+      [1, 2, 3, 4],
+    ]);
+    expect(decodeShareObject(rawResult)).toEqual([
+      [0.5, 0.5],
+      [0.25, 0.75],
+    ]);
   });
 
   it("omits the game result when null is passed", () => {

--- a/src/utils/__tests__/createShareUrl.test.ts
+++ b/src/utils/__tests__/createShareUrl.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { createShareUrl } from "@/utils/createShareUrl";
 import type { GameInputUI, GameResult } from "@/types/game";
-import { DATA_SCHEMA_VERSION } from "@/constants/storage";
+import { SHARE_SCHEMA_VERSION } from "@/constants/storage";
+import { decodeShareObject } from "@/utils/shareCodec";
 
 const sampleInput: GameInputUI = {
   strategyLabels1: ["A", "B"],
@@ -37,7 +38,7 @@ describe("createShareUrl", () => {
     expect(parsedUrl.origin).toBe(window.location.origin);
     expect(parsedUrl.pathname).toBe("/");
     expect(parsedUrl.searchParams.get("schemaVersion")).toBe(
-      String(DATA_SCHEMA_VERSION)
+      String(SHARE_SCHEMA_VERSION)
     );
     expect(parsedUrl.searchParams.get("gameInput")).toBeTruthy();
   });
@@ -46,19 +47,28 @@ describe("createShareUrl", () => {
     const url = createShareUrl(sampleInput, { baseUrl: "https://example.com" });
     const params = new URL(url).searchParams;
 
-    expect(params.get("schemaVersion")).toBe(String(DATA_SCHEMA_VERSION));
+    expect(params.get("schemaVersion")).toBe(String(SHARE_SCHEMA_VERSION));
     expect(params.get("gameInput")).toBeTruthy();
     expect(params.get("gameResult")).toBeNull();
   });
 
-  it("includes the encoded game result when provided", () => {
+  it("includes only result probabilities when provided", () => {
     const url = createShareUrl(sampleInput, {
       baseUrl: "https://example.com/app",
       result: sampleResult,
     });
     const params = new URL(url).searchParams;
+    const rawResult = params.get("gameResult");
 
-    expect(params.get("gameResult")).toBeTruthy();
+    expect(rawResult).toBeTruthy();
+    if (!rawResult) return;
+    expect(decodeShareObject(rawResult)).toEqual({
+      version: SHARE_SCHEMA_VERSION,
+      payload: {
+        player1Probabilities: [0.5, 0.5],
+        player2Probabilities: [0.25, 0.75],
+      },
+    });
   });
 
   it("omits the game result when null is passed", () => {

--- a/src/utils/createShareUrl.ts
+++ b/src/utils/createShareUrl.ts
@@ -1,10 +1,15 @@
-import { DATA_SCHEMA_VERSION } from "@/constants/storage";
+import { SHARE_SCHEMA_VERSION } from "@/constants/storage";
 import type { GameInputUI, GameResult } from "@/types/game";
 import { encodeShareObject } from "@/utils/shareCodec";
 
 export interface CreateShareUrlOptions {
   baseUrl?: string;
   result?: GameResult | null;
+}
+
+export interface SharedGameResultV2 {
+  player1Probabilities: number[];
+  player2Probabilities: number[];
 }
 
 const defaultBaseUrl = () => {
@@ -20,12 +25,23 @@ export function createShareUrl(
 ): string {
   const { baseUrl = defaultBaseUrl(), result } = options;
   const params = new URLSearchParams();
-  params.set("schemaVersion", String(DATA_SCHEMA_VERSION));
+  params.set("schemaVersion", String(SHARE_SCHEMA_VERSION));
   params.set("gameInput", encodeShareObject(inputUI));
 
   if (result) {
-    params.set("gameResult", encodeShareObject(result));
+    params.set("gameResult", encodeShareObject(toSharedGameResultV2(result)));
   }
 
   return `${baseUrl}?${params.toString()}`;
+}
+
+function toSharedGameResultV2(result: GameResult): SharedGameResultV2 {
+  return {
+    player1Probabilities: result.player1Strategy.map(
+      ({ probability }) => probability
+    ),
+    player2Probabilities: result.player2Strategy.map(
+      ({ probability }) => probability
+    ),
+  };
 }

--- a/src/utils/createShareUrl.ts
+++ b/src/utils/createShareUrl.ts
@@ -1,5 +1,6 @@
 import { SHARE_SCHEMA_VERSION } from "@/constants/storage";
 import type { GameInputUI, GameResult } from "@/types/game";
+import { parseGameInputUI } from "@/utils/parseGameInput";
 import { encodeShareObject } from "@/utils/shareCodec";
 
 export interface CreateShareUrlOptions {
@@ -7,9 +8,15 @@ export interface CreateShareUrlOptions {
   result?: GameResult | null;
 }
 
+export interface SharedGameInputV2 {
+  r: string[];
+  c: string[];
+  m: number[];
+}
+
 export interface SharedGameResultV2 {
-  player1Probabilities: number[];
-  player2Probabilities: number[];
+  p: number[];
+  q: number[];
 }
 
 const defaultBaseUrl = () => {
@@ -26,22 +33,31 @@ export function createShareUrl(
   const { baseUrl = defaultBaseUrl(), result } = options;
   const params = new URLSearchParams();
   params.set("schemaVersion", String(SHARE_SCHEMA_VERSION));
-  params.set("gameInput", encodeShareObject(inputUI));
+  params.set("i", encodeShareObject(toSharedGameInputV2(inputUI)));
 
   if (result) {
-    params.set("gameResult", encodeShareObject(toSharedGameResultV2(result)));
+    params.set("r", encodeShareObject(toSharedGameResultV2(result)));
   }
 
   return `${baseUrl}?${params.toString()}`;
 }
 
+function toSharedGameInputV2(inputUI: GameInputUI): SharedGameInputV2 {
+  const parsed = parseGameInputUI(inputUI);
+  if (!parsed.ok) {
+    throw new Error("Cannot share a payoff matrix with invalid numbers");
+  }
+
+  return {
+    r: inputUI.strategyLabels1,
+    c: inputUI.strategyLabels2,
+    m: parsed.data.payoffMatrix.flat(),
+  };
+}
+
 function toSharedGameResultV2(result: GameResult): SharedGameResultV2 {
   return {
-    player1Probabilities: result.player1Strategy.map(
-      ({ probability }) => probability
-    ),
-    player2Probabilities: result.player2Strategy.map(
-      ({ probability }) => probability
-    ),
+    p: result.player1Strategy.map(({ probability }) => probability),
+    q: result.player2Strategy.map(({ probability }) => probability),
   };
 }

--- a/src/utils/createShareUrl.ts
+++ b/src/utils/createShareUrl.ts
@@ -8,16 +8,9 @@ export interface CreateShareUrlOptions {
   result?: GameResult | null;
 }
 
-export interface SharedGameInputV2 {
-  r: string[];
-  c: string[];
-  m: number[];
-}
+export type SharedGameInputV2 = [string[], string[], number[]];
 
-export interface SharedGameResultV2 {
-  p: number[];
-  q: number[];
-}
+export type SharedGameResultV2 = [number[], number[]];
 
 const defaultBaseUrl = () => {
   if (typeof window === "undefined") {
@@ -48,16 +41,16 @@ function toSharedGameInputV2(inputUI: GameInputUI): SharedGameInputV2 {
     throw new Error("Cannot share a payoff matrix with invalid numbers");
   }
 
-  return {
-    r: inputUI.strategyLabels1,
-    c: inputUI.strategyLabels2,
-    m: parsed.data.payoffMatrix.flat(),
-  };
+  return [
+    inputUI.strategyLabels1,
+    inputUI.strategyLabels2,
+    parsed.data.payoffMatrix.flat(),
+  ];
 }
 
 function toSharedGameResultV2(result: GameResult): SharedGameResultV2 {
-  return {
-    p: result.player1Strategy.map(({ probability }) => probability),
-    q: result.player2Strategy.map(({ probability }) => probability),
-  };
+  return [
+    result.player1Strategy.map(({ probability }) => probability),
+    result.player2Strategy.map(({ probability }) => probability),
+  ];
 }

--- a/src/utils/shareCodec.ts
+++ b/src/utils/shareCodec.ts
@@ -2,39 +2,30 @@ import {
   compressToEncodedURIComponent,
   decompressFromEncodedURIComponent,
 } from "lz-string";
-import { SHARE_SCHEMA_VERSION } from "@/constants/storage";
+import { DATA_SCHEMA_VERSION } from "@/constants/storage";
 
-export interface ShareEnvelope<T> {
-  version: number;
+export interface ShareEnvelopeV1<T> {
+  version: typeof DATA_SCHEMA_VERSION;
   payload: T;
 }
 
-// 型安全のためジェネリック
-export function encodeShareObject<T>(
-  obj: T,
-  version: number = SHARE_SCHEMA_VERSION
-): string {
-  const envelope: ShareEnvelope<T> = {
-    version,
+export function encodeShareObject<T>(obj: T): string {
+  return compressToEncodedURIComponent(JSON.stringify(obj));
+}
+
+export function encodeLegacyShareObject<T>(obj: T): string {
+  const envelope: ShareEnvelopeV1<T> = {
+    version: DATA_SCHEMA_VERSION,
     payload: obj,
   };
   return compressToEncodedURIComponent(JSON.stringify(envelope));
 }
 
-export function decodeShareObject<T>(raw: string): ShareEnvelope<T> | null {
+export function decodeShareObject<T>(raw: string): T | null {
   try {
     const json = decompressFromEncodedURIComponent(raw);
     if (!json) return null;
-    const parsed = JSON.parse(json) as Partial<ShareEnvelope<T>>;
-    if (
-      typeof parsed !== "object" ||
-      parsed === null ||
-      typeof parsed.version !== "number" ||
-      !("payload" in parsed)
-    ) {
-      return null;
-    }
-    return parsed as ShareEnvelope<T>;
+    return JSON.parse(json) as T;
   } catch {
     return null;
   }

--- a/src/utils/shareCodec.ts
+++ b/src/utils/shareCodec.ts
@@ -2,7 +2,7 @@ import {
   compressToEncodedURIComponent,
   decompressFromEncodedURIComponent,
 } from "lz-string";
-import { DATA_SCHEMA_VERSION } from "@/constants/storage";
+import { SHARE_SCHEMA_VERSION } from "@/constants/storage";
 
 export interface ShareEnvelope<T> {
   version: number;
@@ -10,9 +10,12 @@ export interface ShareEnvelope<T> {
 }
 
 // 型安全のためジェネリック
-export function encodeShareObject<T>(obj: T): string {
+export function encodeShareObject<T>(
+  obj: T,
+  version: number = SHARE_SCHEMA_VERSION
+): string {
   const envelope: ShareEnvelope<T> = {
-    version: DATA_SCHEMA_VERSION,
+    version,
     payload: obj,
   };
   return compressToEncodedURIComponent(JSON.stringify(envelope));

--- a/src/utils/shareCodec.ts
+++ b/src/utils/shareCodec.ts
@@ -41,7 +41,11 @@ export function decodeLegacyShareObject<T>(
   if (!json) return null;
 
   try {
-    return JSON.parse(json) as ShareEnvelopeV1<T>;
+    const parsed = JSON.parse(json) as unknown;
+    if (!isShareEnvelopeV1<T>(parsed)) {
+      return null;
+    }
+    return parsed;
   } catch {
     return null;
   }
@@ -63,15 +67,30 @@ function decodeLegacyJson(raw: string): string | null {
   }
 }
 
-function bytesToBase64Url(bytes: Uint8Array): string {
-  let binary = "";
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
+function isShareEnvelopeV1<T>(value: unknown): value is ShareEnvelopeV1<T> {
+  if (typeof value !== "object" || value === null) {
+    return false;
   }
-  return btoa(binary)
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/g, "");
+
+  const record = value as Record<string, unknown>;
+  return (
+    record.version === DATA_SCHEMA_VERSION &&
+    Object.prototype.hasOwnProperty.call(record, "payload")
+  );
+}
+
+type RuntimeBuffer = {
+  from(data: Uint8Array): { toString(encoding: "base64"): string };
+  from(data: string, encoding: "base64"): Uint8Array;
+};
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  const runtimeBuffer = getRuntimeBuffer();
+  const base64 = runtimeBuffer
+    ? runtimeBuffer.from(bytes).toString("base64")
+    : bytesToBrowserBase64(bytes);
+
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
 }
 
 function base64UrlToBytes(value: string): Uint8Array {
@@ -80,6 +99,33 @@ function base64UrlToBytes(value: string): Uint8Array {
     base64.length + ((4 - (base64.length % 4)) % 4),
     "="
   );
+
+  const runtimeBuffer = getRuntimeBuffer();
+  if (runtimeBuffer) {
+    return Uint8Array.from(runtimeBuffer.from(padded, "base64"));
+  }
+
   const binary = atob(padded);
-  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+function getRuntimeBuffer(): RuntimeBuffer | undefined {
+  return (globalThis as typeof globalThis & { Buffer?: RuntimeBuffer }).Buffer;
+}
+
+function bytesToBrowserBase64(bytes: Uint8Array): string {
+  const chunkSize = 0x8000;
+  const chunks: string[] = [];
+
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    chunks.push(
+      String.fromCharCode(...bytes.subarray(offset, offset + chunkSize))
+    );
+  }
+
+  return btoa(chunks.join(""));
 }

--- a/src/utils/shareCodec.ts
+++ b/src/utils/shareCodec.ts
@@ -2,6 +2,7 @@ import {
   compressToEncodedURIComponent,
   decompressFromEncodedURIComponent,
 } from "lz-string";
+import { deflateSync, inflateSync, strFromU8, strToU8 } from "fflate";
 import { DATA_SCHEMA_VERSION } from "@/constants/storage";
 
 export interface ShareEnvelopeV1<T> {
@@ -10,7 +11,8 @@ export interface ShareEnvelopeV1<T> {
 }
 
 export function encodeShareObject<T>(obj: T): string {
-  return compressToEncodedURIComponent(JSON.stringify(obj));
+  const compressed = deflateSync(strToU8(JSON.stringify(obj)), { level: 6 });
+  return bytesToBase64Url(compressed);
 }
 
 export function encodeLegacyShareObject<T>(obj: T): string {
@@ -22,11 +24,62 @@ export function encodeLegacyShareObject<T>(obj: T): string {
 }
 
 export function decodeShareObject<T>(raw: string): T | null {
+  const json = decodeDeflatedJson(raw);
+  if (!json) return null;
+
   try {
-    const json = decompressFromEncodedURIComponent(raw);
-    if (!json) return null;
     return JSON.parse(json) as T;
   } catch {
     return null;
   }
+}
+
+export function decodeLegacyShareObject<T>(
+  raw: string
+): ShareEnvelopeV1<T> | null {
+  const json = decodeLegacyJson(raw);
+  if (!json) return null;
+
+  try {
+    return JSON.parse(json) as ShareEnvelopeV1<T>;
+  } catch {
+    return null;
+  }
+}
+
+function decodeDeflatedJson(raw: string): string | null {
+  try {
+    return strFromU8(inflateSync(base64UrlToBytes(raw)));
+  } catch {
+    return null;
+  }
+}
+
+function decodeLegacyJson(raw: string): string | null {
+  try {
+    return decompressFromEncodedURIComponent(raw);
+  } catch {
+    return null;
+  }
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function base64UrlToBytes(value: string): Uint8Array {
+  const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64.padEnd(
+    base64.length + ((4 - (base64.length % 4)) % 4),
+    "="
+  );
+  const binary = atob(padded);
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
 }


### PR DESCRIPTION
## Summary

- Introduce share schema v2 with compact tuple payloads for input and result data.
- Encode v2 share chunks as `JSON -> deflate(level 6) -> base64url` using `fflate`.
- Keep v1 share decoding as a strict legacy path using the existing `lz-string` envelope.
- Clear stale results with a toast when the payoff input changes, so shared results do not mix old probabilities with edited inputs.
- Document compression tradeoffs and future options in #20.

## Why

Large payoff matrices can produce long share URLs. The v2 format removes duplicated labels/matrix data from result payloads, drops per-chunk wrappers, uses tuple payloads, and switches the current share codec to deflate for better compression on larger matrices.

## Validation

- `pnpm exec tsc -b --pretty false`
- `pnpm lint`
- `pnpm test`
- `pnpm format:check`
- `pnpm build`